### PR TITLE
Fixing fetch adapter for non-json responses

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 9,
   "node": true,
   "globals": {"describe" : true, "it" : true}
 }

--- a/lib/httpadapter/fetchadapter.js
+++ b/lib/httpadapter/fetchadapter.js
@@ -40,13 +40,24 @@ class FetchAdapter {
           options
         );
 
-        return res.json();
+        const contentType = res.headers.get('content-type');
+        if (contentType && contentType.indexOf('application/json') !== -1) {
+          return res.json();
+        } else {
+          throw new HttpError(await res.text(), {
+            code: res.statusCode
+          });
+        }
       })
       .catch(function(error) {
-        var _error = error.cause ? error.cause : error;
-        throw new HttpError(_error.message, {
-          code: _error.code
-        });
+        if (error instanceof HttpError) {
+          throw error;
+        } else {
+          const _error = error.cause ? error.cause : error;
+          throw new HttpError(_error.message, {
+            code: _error.code
+          });
+        }
       })
       .asCallback(callback);
   }

--- a/lib/httpadapter/fetchadapter.js
+++ b/lib/httpadapter/fetchadapter.js
@@ -39,25 +39,22 @@ class FetchAdapter {
           url + '?' + querystring.encode(params),
           options
         );
-
         const contentType = res.headers.get('content-type');
-        if (contentType && contentType.indexOf('application/json') !== -1) {
-          return res.json();
-        } else {
+        if (!contentType || contentType.indexOf('application/json') === -1) {
           throw new HttpError(await res.text(), {
             code: res.statusCode
           });
         }
+        return res.json();
       })
       .catch(function(error) {
         if (error instanceof HttpError) {
           throw error;
-        } else {
-          const _error = error.cause ? error.cause : error;
-          throw new HttpError(_error.message, {
-            code: _error.code
-          });
         }
+        const _error = error.cause ? error.cause : error;
+        throw new HttpError(_error.message, {
+          code: _error.code
+        });
       })
       .asCallback(callback);
   }


### PR DESCRIPTION
Current fetch adapter treats all possible responses from providers as jsons, but there are a couple of providers that might return the information as HTML, such as TomTom.

This PR intends to fix this by checking header responses to avoid unexpected exceptions.