### PR TITLE
Fix Here geocoding ApplicationError handling

### DIFF
--- a/lib/geocoder/heregeocoder.js
+++ b/lib/geocoder/heregeocoder.js
@@ -1,4 +1,5 @@
 const AbstractGeocoder = require('./abstractgeocoder');
+const ValueError = require('./../error/valueerror');
 
 const OPTIONS = [
   'apiKey',
@@ -71,6 +72,9 @@ class HereGeocoder extends AbstractGeocoder {
       if (err) {
         return callback(err, results);
       } else {
+        if (result.type === 'ApplicationError') {
+          return callback(new ValueError(result.Details), results);
+        }
         var view = result.Response.View[0];
         if (!view) {
           return callback(false, results);


### PR DESCRIPTION
Before parsing Here response, check if its type is 'ApplicationError' and instead of treating it as successful response, call back with the specific error