### PR TITLE
Support country for TomTom geocoding.

### DIFF
--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -8,7 +8,6 @@ var countries = require('i18n-iso-countries');
  * @param <object> options     Options (language, clientId, apiKey)
  */
 var TomTomGeocoder = function TomTomGeocoder(httpAdapter, options) {
-
   TomTomGeocoder.super_.call(this, httpAdapter, options);
 
   if (!this.options.apiKey || this.options.apiKey == 'undefined') {
@@ -22,16 +21,15 @@ util.inherits(TomTomGeocoder, AbstractGeocoder);
 TomTomGeocoder.prototype._endpoint = 'https://api.tomtom.com/search/2/geocode';
 
 /**
-* Geocode
-* @param <string>   value    Value to geocode (Address)
-* @param <function> callback Callback method
-*/
-TomTomGeocoder.prototype._geocode = function(value, callback) {
-
+ * Geocode
+ * @param <string>   value    Value to geocode (Address)
+ * @param <function> callback Callback method
+ */
+TomTomGeocoder.prototype._geocode = function (value, callback) {
   var _this = this;
 
   var params = {
-    key   : this.options.apiKey
+    key: this.options.apiKey
   };
 
   if (this.options.language) {
@@ -45,32 +43,31 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
       return callback(new Error('You must specify a valid address.'));
     }
 
-    address = value.address.toString()
+    address = value.address.toString();
     if (address === '') {
       return callback(new Error('You must specify a valid address.'));
     }
 
     if (value.country) {
-      const country = value.country.toString()
+      const country = value.country.toString();
       if (typeof country !== 'string' || !countries.isValid(country)) {
         return callback(new Error('Provided country is not valid.'));
       }
 
-      params.country = value.country;
+      params.countrySet = value.country;
     }
   }
 
-  url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
+  url = this._endpoint + '/' + encodeURIComponent(address) + '.json';
 
-
-  this.httpAdapter.get(url, params, function(err, result) {
+  this.httpAdapter.get(url, params, function (err, result) {
     if (err) {
       return callback(err);
     } else {
       var results = [];
 
-      for(var i = 0; i < result.results.length; i++) {
-          results.push(_this._formatResult(result.results[i]));
+      for (var i = 0; i < result.results.length; i++) {
+        results.push(_this._formatResult(result.results[i]));
       }
 
       results.raw = result;
@@ -79,17 +76,17 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
   });
 };
 
-TomTomGeocoder.prototype._formatResult = function(result) {
+TomTomGeocoder.prototype._formatResult = function (result) {
   return {
-    'latitude' : result.position.lat,
-    'longitude' : result.position.lon,
-    'country' : result.address.country,
-    'city' : result.address.localName,
-    'state' : result.address.countrySubdivision,
-    'zipcode' : result.address.postcode,
-    'streetName': result.address.streetName,
-    'streetNumber' : result.address.streetNumber,
-    'countryCode' : result.address.countryCode
+    latitude: result.position.lat,
+    longitude: result.position.lon,
+    country: result.address.country,
+    city: result.address.localName,
+    state: result.address.countrySubdivision,
+    zipcode: result.address.postcode,
+    streetName: result.address.streetName,
+    streetNumber: result.address.streetNumber,
+    countryCode: result.address.countryCode
   };
 };
 

--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var AbstractGeocoder = require('./abstractgeocoder');
+var countries = require('i18n-iso-countries');
 
 /**
  * Constructor
@@ -37,7 +38,30 @@ TomTomGeocoder.prototype._geocode = function(value, callback) {
     params.language = this.options.language;
   }
 
-  var url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
+  var address = value;
+  var url;
+  if (typeof value === 'object') {
+    if (!value.address) {
+      return callback(new Error('You must specify a valid address.'));
+    }
+
+    address = value.address.toString()
+    if (address === '') {
+      return callback(new Error('You must specify a valid address.'));
+    }
+
+    if (value.country) {
+      const country = value.country.toString()
+      if (typeof country !== 'string' || !countries.isValid(country)) {
+        return callback(new Error('Provided country is not valid.'));
+      }
+
+      params.country = value.country;
+    }
+  }
+
+  url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
+
 
   this.httpAdapter.get(url, params, function(err, result) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.2",
+    "i18n-iso-countries": "^7.2.0",
     "node-fetch": "^2.6.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.2"


### PR DESCRIPTION
Forward geocoding for TomTom only supports the address. This fix adds support for sending an address (as string) or an object of parameters (only `country` for now).