### PR TITLE
Support country param for TomTom geocoder

### DIFF
--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -37,6 +37,10 @@ TomTomGeocoder.prototype._geocode = function (value, callback) {
     params.language = this.options.language;
   }
 
+  if (this.options.country) {
+    params.countrySet = this.options.country;
+  }
+
   var url = this._endpoint + '/' + encodeURIComponent(value) + '.json';
 
   this.httpAdapter.get(url, params, function (err, result) {


### PR DESCRIPTION
- Shortcut story: https://app.shortcut.com/cartoteam/story/202673/support-country-argument-in-geocoding-for-tomtom
- Related PR in `cloud-native`: https://github.com/CartoDB/cloud-native/pull/4545