### PR TITLE
fix: tomtom batch geocoder for node-fetch >= 3.1.1

### DIFF
--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -155,7 +155,7 @@ TomTomGeocoder.prototype.__createJob = async function (addresses) {
   if (!location) {
     throw new Error('Location header not found');
   }
-  return location;
+  return (new URL(location, response.url)).href
 };
 
 TomTomGeocoder.prototype.__pollJobStatusAndFetchResults = async function (
@@ -186,6 +186,7 @@ TomTomGeocoder.prototype.__pollJobStatusAndFetchResults = async function (
       if (!newLocation) {
         throw new Error('Location header not found');
       }
+      newLocation = (new URL(newLocation, status.url)).href
     } else if (status.status === 429) {
       throw new Error('Provider error: Too many requests');
     } else {


### PR DESCRIPTION
The TomTom batch geocoder doesn't work with recent fetch versions because of this: https://github.com/node-fetch/node-fetch/commit/5304f3f7f7778f1011b622bedcb0e4d3c04dba31 (the location header, for manual redirects, used to be fixed to contain a complete URL, but now it is relative).

