### PR TITLE
TomTom geocoding, fallback from localName to municipality for city

### DIFF
--- a/lib/geocoder/tomtomgeocoder.js
+++ b/lib/geocoder/tomtomgeocoder.js
@@ -68,7 +68,7 @@ TomTomGeocoder.prototype._formatResult = function (result) {
     latitude: result.position.lat,
     longitude: result.position.lon,
     country: result.address.country,
-    city: result.address.localName,
+    city: result.address.localName || result.address.municipality,
     state: result.address.countrySubdivision,
     zipcode: result.address.postcode,
     streetName: result.address.streetName,


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/501691/costco-wholesale-corporation-geocode-table-is-not-returning-all-expected-metadata
- Autolink: [sc-501691]

TomTom batch async gecoding: Fallback to munipacipality for city.
